### PR TITLE
feat: 영화 찜 추가 기능 구현 및 테스트 코드 작성

### DIFF
--- a/src/main/java/org/example/pedia_777/common/code/ErrorCode.java
+++ b/src/main/java/org/example/pedia_777/common/code/ErrorCode.java
@@ -24,7 +24,8 @@ public enum ErrorCode {
     NOT_FOUND_EMAIL_PASSWORD(HttpStatus.NOT_FOUND, "이메일 혹은 비밀번호를 찾을 수 없습니다."),
 
     // favorite
-  
+    FAVORITE_ALREADY_EXISTS(HttpStatus.BAD_REQUEST, "이미 찜을 추가한 영화입니다."),
+
     // movie
     MOVIE_NOT_FOUND(HttpStatus.NOT_FOUND, "영화를 찾을 수 없습니다."),
 

--- a/src/main/java/org/example/pedia_777/common/code/SuccessCode.java
+++ b/src/main/java/org/example/pedia_777/common/code/SuccessCode.java
@@ -9,20 +9,21 @@ import org.springframework.http.HttpStatus;
 public enum SuccessCode {
 
 
-	  // common
-	  REQUEST_SUCCESS(HttpStatus.OK, "요청이 성공적으로 처리되었습니다."),
+    // common
+    REQUEST_SUCCESS(HttpStatus.OK, "요청이 성공적으로 처리되었습니다."),
 
-	  // member
-	  SIGNUP_SUCCESS(HttpStatus.OK, "회원가입이 성공적으로 처리되었습니다."),
-	  LOGIN_SUCCESS(HttpStatus.OK, "로그인이 완료되었습니다."),
+    // member
+    SIGNUP_SUCCESS(HttpStatus.OK, "회원가입이 성공적으로 처리되었습니다."),
+    LOGIN_SUCCESS(HttpStatus.OK, "로그인이 완료되었습니다."),
 
     // favorite
+    FAVORITE_ADD_SUCCESS(HttpStatus.OK, "찜이 성공적으로 추가되었습니다."),
 
     // movie
 
     // review
     REVIEW_SUCCESS(HttpStatus.OK, "리뷰 생성이 성공적으로 처리되었습니다.");
-  
+
     // like
 
     // search history

--- a/src/main/java/org/example/pedia_777/domain/favorite/controller/FavoriteController.java
+++ b/src/main/java/org/example/pedia_777/domain/favorite/controller/FavoriteController.java
@@ -1,0 +1,33 @@
+package org.example.pedia_777.domain.favorite.controller;
+
+import lombok.RequiredArgsConstructor;
+import org.example.pedia_777.common.code.SuccessCode;
+import org.example.pedia_777.common.dto.AuthMember;
+import org.example.pedia_777.common.dto.GlobalApiResponse;
+import org.example.pedia_777.common.util.ResponseHelper;
+import org.example.pedia_777.domain.favorite.dto.response.FavoriteAddResponse;
+import org.example.pedia_777.domain.favorite.service.FavoriteService;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/movies")
+public class FavoriteController {
+
+    private final FavoriteService favoriteService;
+
+    @PostMapping("/{movieId}/hearts")
+    public ResponseEntity<GlobalApiResponse<FavoriteAddResponse>> addHeart(
+            @AuthenticationPrincipal AuthMember authMember,
+            @PathVariable Long movieId) {
+
+        FavoriteAddResponse response = favoriteService.addHeart(authMember.id(), movieId);
+
+        return ResponseHelper.success(SuccessCode.FAVORITE_ADD_SUCCESS, response);
+    }
+}

--- a/src/main/java/org/example/pedia_777/domain/favorite/dto/response/FavoriteAddResponse.java
+++ b/src/main/java/org/example/pedia_777/domain/favorite/dto/response/FavoriteAddResponse.java
@@ -1,0 +1,12 @@
+package org.example.pedia_777.domain.favorite.dto.response;
+
+public record FavoriteAddResponse(
+        Long movieId,
+        String title,
+        boolean isHeart
+) {
+
+    public static FavoriteAddResponse of(Long movieId, String title, boolean isHeart) {
+        return new FavoriteAddResponse(movieId, title, isHeart);
+    }
+}

--- a/src/main/java/org/example/pedia_777/domain/favorite/entity/Favorite.java
+++ b/src/main/java/org/example/pedia_777/domain/favorite/entity/Favorite.java
@@ -7,6 +7,7 @@ import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.ManyToOne;
 import lombok.AccessLevel;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.example.pedia_777.common.entity.BaseTimeEntity;
@@ -27,4 +28,17 @@ public class Favorite extends BaseTimeEntity {
 
     @ManyToOne(fetch = FetchType.LAZY)
     private Movie movie;
+
+    @Builder
+    private Favorite(Member member, Movie movie) {
+        this.member = member;
+        this.movie = movie;
+    }
+
+    public static Favorite create(Member member, Movie movie) {
+        return Favorite.builder()
+                .member(member)
+                .movie(movie)
+                .build();
+    }
 }

--- a/src/main/java/org/example/pedia_777/domain/favorite/repository/FavoriteRepository.java
+++ b/src/main/java/org/example/pedia_777/domain/favorite/repository/FavoriteRepository.java
@@ -1,0 +1,10 @@
+package org.example.pedia_777.domain.favorite.repository;
+
+import java.util.Optional;
+import org.example.pedia_777.domain.favorite.entity.Favorite;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface FavoriteRepository extends JpaRepository<Favorite, Long> {
+
+    Optional<Favorite> findByMemberIdAndMovieId(Long memberId, Long movieId);
+}

--- a/src/main/java/org/example/pedia_777/domain/favorite/service/FavoriteService.java
+++ b/src/main/java/org/example/pedia_777/domain/favorite/service/FavoriteService.java
@@ -1,0 +1,39 @@
+package org.example.pedia_777.domain.favorite.service;
+
+import lombok.RequiredArgsConstructor;
+import org.example.pedia_777.common.code.ErrorCode;
+import org.example.pedia_777.common.exception.BusinessException;
+import org.example.pedia_777.domain.favorite.dto.response.FavoriteAddResponse;
+import org.example.pedia_777.domain.favorite.entity.Favorite;
+import org.example.pedia_777.domain.favorite.repository.FavoriteRepository;
+import org.example.pedia_777.domain.member.entity.Member;
+import org.example.pedia_777.domain.member.service.MemberServiceApi;
+import org.example.pedia_777.domain.movie.entity.Movie;
+import org.example.pedia_777.domain.movie.service.MovieServiceApi;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class FavoriteService {
+
+    private final FavoriteRepository favoriteRepository;
+    private final MovieServiceApi movieServiceApi;
+    private final MemberServiceApi memberServiceApi;
+
+    public FavoriteAddResponse addHeart(Long memberId, Long movieId) {
+
+        Member member = memberServiceApi.findMemberById(memberId);
+        Movie movie = movieServiceApi.findMovieById((movieId));
+
+        if (favoriteRepository.findByMemberIdAndMovieId(memberId, movieId).isPresent()) {
+            throw new BusinessException(ErrorCode.FAVORITE_ALREADY_EXISTS);
+        }
+
+        Favorite heart = Favorite.create(member, movie);
+        favoriteRepository.save(heart);
+
+        return FavoriteAddResponse.of(movieId, movie.getTitle(), true);
+    }
+}

--- a/src/test/java/org/example/pedia_777/domain/favorite/service/FavoriteServiceTest.java
+++ b/src/test/java/org/example/pedia_777/domain/favorite/service/FavoriteServiceTest.java
@@ -1,0 +1,112 @@
+package org.example.pedia_777.domain.favorite.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+
+import java.time.LocalDateTime;
+import java.util.Optional;
+import org.example.pedia_777.common.code.ErrorCode;
+import org.example.pedia_777.common.exception.BusinessException;
+import org.example.pedia_777.domain.favorite.dto.response.FavoriteAddResponse;
+import org.example.pedia_777.domain.favorite.entity.Favorite;
+import org.example.pedia_777.domain.favorite.repository.FavoriteRepository;
+import org.example.pedia_777.domain.member.entity.Member;
+import org.example.pedia_777.domain.member.service.MemberServiceApi;
+import org.example.pedia_777.domain.movie.entity.Movie;
+import org.example.pedia_777.domain.movie.service.MovieServiceApi;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class FavoriteServiceTest {
+
+    @InjectMocks
+    private FavoriteService favoriteService;
+
+    @Mock
+    private FavoriteRepository favoriteRepository;
+
+    @Mock
+    private MemberServiceApi memberServiceApi;
+
+    @Mock
+    private MovieServiceApi movieServiceApi;
+
+    // 테스트 데이터
+    private Member testMember;
+    private Movie testMovie;
+    private Long memberId = 1L;
+    private Long movieId = 1L;
+
+    @BeforeEach
+    void setUp() {
+        testMember = Member.signUp(
+                "test@test.com",
+                "password",
+                "testUser"
+        );
+
+        testMovie = Movie.of(
+                "감독",
+                "테스트 영화",
+                "배우1, 배우2",
+                "코미디",
+                LocalDateTime.now(),
+                120L,
+                "한국",
+                "영화 줄거리",
+                "http://test.url"
+        );
+    }
+
+
+    @Test
+    @DisplayName("영화 찜 추가 시 성공적으로 추가된다.")
+    void addFavoriteSuccess() {
+
+        // given
+        given(memberServiceApi.findMemberById(memberId)).willReturn(testMember);
+        given(movieServiceApi.findMovieById(movieId)).willReturn(testMovie);
+        given(favoriteRepository.findByMemberIdAndMovieId(memberId, movieId)).willReturn(Optional.empty());
+
+        // when
+        FavoriteAddResponse response = favoriteService.addHeart(memberId, movieId);
+
+        // then
+        assertThat(response.movieId()).isEqualTo(movieId);
+        assertThat(response.title()).isEqualTo(testMovie.getTitle());
+        assertThat(response.isHeart()).isTrue();
+
+        verify(favoriteRepository).save(any(Favorite.class));
+    }
+
+    @Test
+    @DisplayName("영화 찜 추가 시 이미 찜한 경우 예외 처리가 발생한다.")
+    void addFavoriteFail_AlreadyExists() {
+
+        // given
+        given(memberServiceApi.findMemberById(memberId)).willReturn(testMember);
+        given(movieServiceApi.findMovieById(movieId)).willReturn(testMovie);
+        given(favoriteRepository.findByMemberIdAndMovieId(memberId, movieId)).willReturn(
+                Optional.of(Favorite.create(testMember, testMovie)));
+
+        // when & then
+        BusinessException exception = assertThrows(BusinessException.class, () -> {
+            favoriteService.addHeart(memberId, movieId);
+        });
+
+        assertEquals(ErrorCode.FAVORITE_ALREADY_EXISTS, exception.getErrorCode());
+        verify(favoriteRepository, never()).save(any(Favorite.class));
+    }
+
+}


### PR DESCRIPTION
## 🔗 **연관된 이슈**
> close #12 

<br>

## 📝 **작업 내용**

- Favorite 도메인 관련 클래스 추가 및 구현
  - `FavoriteController` : 컨트롤러
  - `FavoriteService` : 찜 추가 로직 처리 서비스
  - `FavoriteRepository` : 레포지토리 인터페이스
  - Favorite: 찜 엔티티
  - FavoriteAddResponse: 찜 추가 성공 시 응답 DTO

- `POST /api/v1/movies/{movieId}/hearts`

- 단위 테스트 코드 작성 (FavoriteService)
  - 성공 케이스
  - 예외 케이스
<br>

## 📸 **스크린샷 (Optional)**

<br>