### PR TITLE
feat: 영화 찜 해제 기능 구현 및 테스트 코드 작성

### DIFF
--- a/src/main/java/org/example/pedia_777/domain/favorite/code/FavoriteErrorCode.java
+++ b/src/main/java/org/example/pedia_777/domain/favorite/code/FavoriteErrorCode.java
@@ -9,7 +9,8 @@ import org.springframework.http.HttpStatus;
 @RequiredArgsConstructor
 public enum FavoriteErrorCode implements Code {
 
-    FAVORITE_ALREADY_EXISTS(HttpStatus.BAD_REQUEST, "이미 찜을 추가한 영화입니다.");
+    FAVORITE_ALREADY_EXISTS(HttpStatus.BAD_REQUEST, "이미 찜을 추가한 영화입니다."),
+    FAVORITE_NOT_FOUND(HttpStatus.NOT_FOUND, "찜을 찾을 수 없습니다.");
 
     private final HttpStatus httpStatus;
     private final String messageTemplate;

--- a/src/main/java/org/example/pedia_777/domain/favorite/controller/FavoriteController.java
+++ b/src/main/java/org/example/pedia_777/domain/favorite/controller/FavoriteController.java
@@ -22,11 +22,11 @@ public class FavoriteController {
     private final FavoriteService favoriteService;
 
     @PostMapping("/{movieId}/favorites")
-    public ResponseEntity<GlobalApiResponse<FavoriteAddResponse>> addHeart(
+    public ResponseEntity<GlobalApiResponse<FavoriteAddResponse>> addFavorite(
             @AuthenticationPrincipal AuthMember authMember,
             @PathVariable Long movieId) {
 
-        FavoriteAddResponse response = favoriteService.addHeart(authMember.id(), movieId);
+        FavoriteAddResponse response = favoriteService.addFavorite(authMember.id(), movieId);
 
         return ResponseHelper.success(CommonSuccessCode.CREATED_SUCCESS, response);
     }

--- a/src/main/java/org/example/pedia_777/domain/favorite/controller/FavoriteController.java
+++ b/src/main/java/org/example/pedia_777/domain/favorite/controller/FavoriteController.java
@@ -9,6 +9,7 @@ import org.example.pedia_777.domain.favorite.dto.response.FavoriteAddResponse;
 import org.example.pedia_777.domain.favorite.service.FavoriteService;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -29,5 +30,15 @@ public class FavoriteController {
         FavoriteAddResponse response = favoriteService.addFavorite(authMember.id(), movieId);
 
         return ResponseHelper.success(CommonSuccessCode.CREATED_SUCCESS, response);
+    }
+
+    @DeleteMapping("/{movieId}/favorites")
+    public ResponseEntity<GlobalApiResponse<Void>> removeFavorite(
+            @AuthenticationPrincipal AuthMember authMember,
+            @PathVariable Long movieId) {
+
+        favoriteService.removeFavorite(authMember.id(), movieId);
+
+        return ResponseHelper.success(CommonSuccessCode.DELETED_SUCCESS);
     }
 }

--- a/src/main/java/org/example/pedia_777/domain/favorite/dto/response/FavoriteAddResponse.java
+++ b/src/main/java/org/example/pedia_777/domain/favorite/dto/response/FavoriteAddResponse.java
@@ -3,10 +3,10 @@ package org.example.pedia_777.domain.favorite.dto.response;
 public record FavoriteAddResponse(
         Long movieId,
         String title,
-        boolean isHeart
+        boolean isFavorite
 ) {
 
-    public static FavoriteAddResponse of(Long movieId, String title, boolean isHeart) {
-        return new FavoriteAddResponse(movieId, title, isHeart);
+    public static FavoriteAddResponse of(Long movieId, String title, boolean isFavorite) {
+        return new FavoriteAddResponse(movieId, title, isFavorite);
     }
 }

--- a/src/main/java/org/example/pedia_777/domain/favorite/service/FavoriteService.java
+++ b/src/main/java/org/example/pedia_777/domain/favorite/service/FavoriteService.java
@@ -36,4 +36,12 @@ public class FavoriteService {
 
         return FavoriteAddResponse.of(movieId, movie.getTitle(), true);
     }
+
+    public void removeFavorite(Long memberId, Long movieId) {
+
+        Favorite favorite = favoriteRepository.findByMemberIdAndMovieId(memberId, movieId)
+                .orElseThrow(() -> new BusinessException(FavoriteErrorCode.FAVORITE_NOT_FOUND));
+
+        favoriteRepository.delete(favorite);
+    }
 }

--- a/src/main/java/org/example/pedia_777/domain/favorite/service/FavoriteService.java
+++ b/src/main/java/org/example/pedia_777/domain/favorite/service/FavoriteService.java
@@ -22,7 +22,7 @@ public class FavoriteService {
     private final MovieServiceApi movieServiceApi;
     private final MemberServiceApi memberServiceApi;
 
-    public FavoriteAddResponse addHeart(Long memberId, Long movieId) {
+    public FavoriteAddResponse addFavorite(Long memberId, Long movieId) {
 
         Member member = memberServiceApi.findMemberById(memberId);
         Movie movie = movieServiceApi.findMovieById((movieId));
@@ -31,8 +31,8 @@ public class FavoriteService {
             throw new BusinessException(FavoriteErrorCode.FAVORITE_ALREADY_EXISTS);
         }
 
-        Favorite heart = Favorite.create(member, movie);
-        favoriteRepository.save(heart);
+        Favorite favorite = Favorite.create(member, movie);
+        favoriteRepository.save(favorite);
 
         return FavoriteAddResponse.of(movieId, movie.getTitle(), true);
     }

--- a/src/test/java/org/example/pedia_777/domain/favorite/service/FavoriteServiceTest.java
+++ b/src/test/java/org/example/pedia_777/domain/favorite/service/FavoriteServiceTest.java
@@ -105,4 +105,33 @@ class FavoriteServiceTest {
         verify(favoriteRepository, never()).save(any(Favorite.class));
     }
 
+    @Test
+    @DisplayName("영화 찜 해제 시 성공적으로 삭제된다.")
+    void removeFavoriteSuccess() {
+
+        // given
+        Favorite favorite = Favorite.create(testMember, testMovie);
+        given(favoriteRepository.findByMemberIdAndMovieId(memberId, movieId)).willReturn(Optional.of(favorite));
+
+        // when
+        favoriteService.removeFavorite(memberId, movieId);
+
+        // then
+        verify(favoriteRepository).delete(favorite);
+    }
+
+    @Test
+    @DisplayName("영화 찜 해제 시 찜하지 않은 영화인 경우 예외 발생한다.")
+    void removeFavoriteFail_NotFound() {
+
+        // given
+        given(favoriteRepository.findByMemberIdAndMovieId(memberId, movieId)).willReturn(Optional.empty());
+
+        // when & then
+        BusinessException exception = assertThrows(BusinessException.class, () -> {
+            favoriteService.removeFavorite(memberId, movieId);
+        });
+
+        assertEquals(FavoriteErrorCode.FAVORITE_NOT_FOUND, exception.getErrorCode());
+    }
 }

--- a/src/test/java/org/example/pedia_777/domain/favorite/service/FavoriteServiceTest.java
+++ b/src/test/java/org/example/pedia_777/domain/favorite/service/FavoriteServiceTest.java
@@ -76,12 +76,12 @@ class FavoriteServiceTest {
         given(favoriteRepository.findByMemberIdAndMovieId(memberId, movieId)).willReturn(Optional.empty());
 
         // when
-        FavoriteAddResponse response = favoriteService.addHeart(memberId, movieId);
+        FavoriteAddResponse response = favoriteService.addFavorite(memberId, movieId);
 
         // then
         assertThat(response.movieId()).isEqualTo(movieId);
         assertThat(response.title()).isEqualTo(testMovie.getTitle());
-        assertThat(response.isHeart()).isTrue();
+        assertThat(response.isFavorite()).isTrue();
 
         verify(favoriteRepository).save(any(Favorite.class));
     }
@@ -98,7 +98,7 @@ class FavoriteServiceTest {
 
         // when & then
         BusinessException exception = assertThrows(BusinessException.class, () -> {
-            favoriteService.addHeart(memberId, movieId);
+            favoriteService.addFavorite(memberId, movieId);
         });
 
         assertEquals(FavoriteErrorCode.FAVORITE_ALREADY_EXISTS, exception.getErrorCode());


### PR DESCRIPTION
## 🔗 **연관된 이슈**
> close #13 

<br>

## 📝 **작업 내용**

- 찜 해제 기능 구현을 위한 Favorite 도메인 클래스 구현
  - `FavoriteController` : `removeFavorite` 메서드 구현
  - `FavoriteErrorCode` : 에러 코드 추가
  - `FavoriteService` : `removeFavorite` 비즈니스 로직 구현

- DELETE /api/v1/movies/{movieId}/favorites

- 단위 테스트 코드 작성
  - 찜 해제 성공 케이스
  - 찜 해제 실패 케이스 (찜한 영화가 아닌데 시도할 경우)

<br>

## 📸 **스크린샷 (Optional)**

<br>