### PR TITLE
feat: 영화 검색 API v2

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -30,6 +30,7 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-security'
     implementation 'org.springframework.boot:spring-boot-starter-validation'
     implementation 'org.springframework.boot:spring-boot-starter-web'
+    implementation 'org.springframework.boot:spring-boot-starter-cache'
     compileOnly 'org.projectlombok:lombok'
     runtimeOnly 'com.mysql:mysql-connector-j'
     annotationProcessor 'org.projectlombok:lombok'
@@ -52,6 +53,9 @@ dependencies {
     // queryDSL
     implementation 'io.github.openfeign.querydsl:querydsl-jpa:7.0'
     annotationProcessor 'io.github.openfeign.querydsl:querydsl-apt:7.0:jpa'
+
+    // cache
+    implementation 'com.github.ben-manes.caffeine:caffeine:3.2.2'
 }
 
 tasks.named('test') {

--- a/build.gradle
+++ b/build.gradle
@@ -37,6 +37,10 @@ dependencies {
     testImplementation 'org.springframework.security:spring-security-test'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 
+    // 테스트 코드용 Lombok
+    testCompileOnly 'org.projectlombok:lombok'
+    testAnnotationProcessor 'org.projectlombok:lombok'
+
     // bcrypt
     implementation 'at.favre.lib:bcrypt:0.10.2'
 

--- a/src/main/java/org/example/pedia_777/common/config/CacheConfig.java
+++ b/src/main/java/org/example/pedia_777/common/config/CacheConfig.java
@@ -1,0 +1,29 @@
+package org.example.pedia_777.common.config;
+
+import com.github.benmanes.caffeine.cache.Caffeine;
+import java.util.concurrent.TimeUnit;
+import org.springframework.cache.CacheManager;
+import org.springframework.cache.annotation.EnableCaching;
+import org.springframework.cache.caffeine.CaffeineCacheManager;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+@EnableCaching
+public class CacheConfig {
+
+    @Bean
+    public CacheManager cacheManager() {
+
+        CaffeineCacheManager cacheManager = new CaffeineCacheManager();
+
+        cacheManager.registerCustomCache(CacheType.MOVIE_SEARCH_NAME,
+                Caffeine.newBuilder()
+                        .recordStats()
+                        .expireAfterWrite(CacheType.MOVIE_SEARCH.getExpiredAfterWrite(), TimeUnit.MINUTES)
+                        .maximumSize(CacheType.MOVIE_SEARCH.getMaximumSize())
+                        .build());
+
+        return cacheManager;
+    }
+}

--- a/src/main/java/org/example/pedia_777/common/config/CacheType.java
+++ b/src/main/java/org/example/pedia_777/common/config/CacheType.java
@@ -1,0 +1,17 @@
+package org.example.pedia_777.common.config;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum CacheType {
+
+    MOVIE_SEARCH("movieSearch", 10, 5000); // 10분, 5,000개
+
+    public static final String MOVIE_SEARCH_NAME = "movieSearch";
+
+    private final String cacheName;
+    private final long expiredAfterWrite;
+    private final int maximumSize;
+}

--- a/src/main/java/org/example/pedia_777/domain/movie/repository/MovieRepository.java
+++ b/src/main/java/org/example/pedia_777/domain/movie/repository/MovieRepository.java
@@ -1,8 +1,31 @@
 package org.example.pedia_777.domain.movie.repository;
 
 import org.example.pedia_777.domain.movie.entity.Movie;
+import org.example.pedia_777.domain.search.dto.response.MovieSearchProjection;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface MovieRepository extends JpaRepository<Movie, Long>, MovieRepositoryCustom {
 
+    @Query(value = """
+            SELECT m.id, m.title, m.director, m.actors, m.poster_url,
+                   AVG(r.star) AS avgStar,
+                   COUNT(DISTINCT r.id) AS reviewCount,
+                   COUNT(DISTINCT f.id) AS favoriteCount
+            FROM movie m
+            LEFT JOIN review r ON r.movies_id = m.id AND r.deleted_at IS NULL
+            LEFT JOIN favorite f ON f.movie_id = m.id
+            WHERE MATCH(m.title, m.director, m.actors) AGAINST (:keyword IN BOOLEAN MODE)       
+            GROUP BY m.id
+            """,
+            countQuery = """
+                    SELECT COUNT(*) 
+                    FROM movie m 
+                    WHERE MATCH(m.title, m.director, m.actors) AGAINST (:keyword IN BOOLEAN MODE)
+                    """,
+            nativeQuery = true)
+    Page<MovieSearchProjection> searchMoviesNative(@Param("keyword") String keyword, Pageable pageable);
 }

--- a/src/main/java/org/example/pedia_777/domain/movie/repository/MovieRepositoryCustomImpl.java
+++ b/src/main/java/org/example/pedia_777/domain/movie/repository/MovieRepositoryCustomImpl.java
@@ -39,9 +39,9 @@ public class MovieRepositoryCustomImpl implements MovieRepositoryCustom {
                 .from(movie)
                 .leftJoin(review).on(review.movie.id.eq(movie.id))
                 .leftJoin(favorite).on(favorite.movie.id.eq(movie.id))
-                .where(movie.title.startsWithIgnoreCase(keyword)
-                        .or(movie.director.startsWithIgnoreCase(keyword))
-                        .or(movie.actors.startsWithIgnoreCase(keyword)))
+                .where(movie.title.containsIgnoreCase(keyword)
+                        .or(movie.director.containsIgnoreCase(keyword))
+                        .or(movie.actors.containsIgnoreCase(keyword)))
                 .groupBy(movie.id)
                 .offset(pageable.getOffset())
                 .limit(pageable.getPageSize())
@@ -51,9 +51,9 @@ public class MovieRepositoryCustomImpl implements MovieRepositoryCustom {
         JPAQuery<Long> countQuery = queryFactory
                 .select(movie.count())
                 .from(movie)
-                .where(movie.title.startsWithIgnoreCase(keyword)
-                        .or(movie.director.startsWithIgnoreCase(keyword))
-                        .or(movie.actors.startsWithIgnoreCase(keyword)));
+                .where(movie.title.containsIgnoreCase(keyword)
+                        .or(movie.director.containsIgnoreCase(keyword))
+                        .or(movie.actors.containsIgnoreCase(keyword)));
 
         return PageableExecutionUtils.getPage(content, pageable, countQuery::fetchOne);
     }

--- a/src/main/java/org/example/pedia_777/domain/movie/repository/MovieRepositoryCustomImpl.java
+++ b/src/main/java/org/example/pedia_777/domain/movie/repository/MovieRepositoryCustomImpl.java
@@ -39,9 +39,9 @@ public class MovieRepositoryCustomImpl implements MovieRepositoryCustom {
                 .from(movie)
                 .leftJoin(review).on(review.movie.id.eq(movie.id))
                 .leftJoin(favorite).on(favorite.movie.id.eq(movie.id))
-                .where(movie.title.containsIgnoreCase(keyword)
-                        .or(movie.director.containsIgnoreCase(keyword))
-                        .or(movie.actors.containsIgnoreCase(keyword)))
+                .where(movie.title.startsWithIgnoreCase(keyword)
+                        .or(movie.director.startsWithIgnoreCase(keyword))
+                        .or(movie.actors.startsWithIgnoreCase(keyword)))
                 .groupBy(movie.id)
                 .offset(pageable.getOffset())
                 .limit(pageable.getPageSize())
@@ -51,9 +51,9 @@ public class MovieRepositoryCustomImpl implements MovieRepositoryCustom {
         JPAQuery<Long> countQuery = queryFactory
                 .select(movie.count())
                 .from(movie)
-                .where(movie.title.containsIgnoreCase(keyword)
-                        .or(movie.director.containsIgnoreCase(keyword))
-                        .or(movie.actors.containsIgnoreCase(keyword)));
+                .where(movie.title.startsWithIgnoreCase(keyword)
+                        .or(movie.director.startsWithIgnoreCase(keyword))
+                        .or(movie.actors.startsWithIgnoreCase(keyword)));
 
         return PageableExecutionUtils.getPage(content, pageable, countQuery::fetchOne);
     }

--- a/src/main/java/org/example/pedia_777/domain/movie/service/MovieService.java
+++ b/src/main/java/org/example/pedia_777/domain/movie/service/MovieService.java
@@ -34,5 +34,11 @@ public class MovieService implements MovieServiceApi {
     public Page<MovieSearchResponse> searchMovies(String keyword, Pageable pageable) {
         return movieRepository.searchMovies(keyword, pageable)
                 .map(MovieSearchResponse::from);
+
+        // fulltext index 테스트를 위한 코드, 삭제 예정
+//        String fullTextKeyword = keyword;
+//        String fullTextKeyword = "+" + keyword + "*";
+//        return movieRepository.searchMoviesNative(fullTextKeyword, pageable)
+//                .map(MovieSearchResponse::from);
     }
 }

--- a/src/main/java/org/example/pedia_777/domain/search/controller/SearchController.java
+++ b/src/main/java/org/example/pedia_777/domain/search/controller/SearchController.java
@@ -28,4 +28,13 @@ public class SearchController {
         return ResponseHelper.success(CommonSuccessCode.REQUEST_SUCCESS,
                 searchService.searchMovies(keyword, pageable));
     }
+
+    @GetMapping("/api/v2/search")
+    public ResponseEntity<GlobalApiResponse<PageResponse<MovieSearchResponse>>> searchMoviesWithLocalCache(
+            @RequestParam String keyword,
+            @PageableDefault(size = 10) Pageable pageable) {
+
+        return ResponseHelper.success(CommonSuccessCode.REQUEST_SUCCESS,
+                searchService.searchMoviesWithLocalCache(keyword, pageable));
+    }
 }

--- a/src/main/java/org/example/pedia_777/domain/search/service/SearchService.java
+++ b/src/main/java/org/example/pedia_777/domain/search/service/SearchService.java
@@ -1,12 +1,16 @@
 package org.example.pedia_777.domain.search.service;
 
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.example.pedia_777.common.config.CacheType;
 import org.example.pedia_777.common.dto.PageResponse;
 import org.example.pedia_777.domain.movie.service.MovieService;
 import org.example.pedia_777.domain.search.dto.response.MovieSearchResponse;
+import org.springframework.cache.annotation.Cacheable;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 
+@Slf4j
 @RequiredArgsConstructor
 @Service
 public class SearchService {
@@ -17,4 +21,18 @@ public class SearchService {
 
         return PageResponse.from(movieService.searchMovies(keyword, pageable));
     }
+
+    @Cacheable(
+            cacheNames = CacheType.MOVIE_SEARCH_NAME,
+            key = "'search:' + #keyword.trim().toLowerCase() + ':' + #pageable.pageNumber + ':' + #pageable.pageSize",
+            condition = "#keyword != null && #keyword.trim().length() <= 30 && #pageable.pageSize <= 30 && #pageable.pageNumber <= 3",
+            unless = "#result == null || #result.content.isEmpty()")
+    public PageResponse<MovieSearchResponse> searchMoviesWithLocalCache(String keyword, Pageable pageable) {
+
+        log.info("[SearchService] searchMoviesWithLocalCache DB 연결 | keyword: {}, pageSize: {}, pageNumber: {}",
+                keyword,
+                pageable.getPageSize(), pageable.getPageNumber());
+        return PageResponse.from(movieService.searchMovies(keyword, pageable));
+    }
+
 }

--- a/src/test/java/org/example/pedia_777/domain/search/service/SearchServicePerformanceTest.java
+++ b/src/test/java/org/example/pedia_777/domain/search/service/SearchServicePerformanceTest.java
@@ -24,7 +24,7 @@ class SearchServicePerformanceTest {
     @DisplayName("영화 검색 간단 성능 테스트")
     void searchMovies_performanceTest() {
 
-        String keyword = "위대한";
+        String keyword = "영웅";
         int PAGE_SIZE = 30;
         int TOTAL_ITERATIONS = 13;
         int WARMUP_ITERATIONS = 3;
@@ -40,7 +40,7 @@ class SearchServicePerformanceTest {
             var result = searchService.searchMovies(keyword, pageable);
 
             stopWatch.stop();
-            long diff = stopWatch.getTotalTimeMillis();
+            long diff = stopWatch.lastTaskInfo().getTimeMillis();
 
             if (i <= WARMUP_ITERATIONS) {
                 log.info("[{} Warm-up] 검색된 영화 수 = {}, 실행 시간 = {} ms",

--- a/src/test/java/org/example/pedia_777/domain/search/service/SearchServicePerformanceTest.java
+++ b/src/test/java/org/example/pedia_777/domain/search/service/SearchServicePerformanceTest.java
@@ -1,0 +1,57 @@
+package org.example.pedia_777.domain.search.service;
+
+import java.util.ArrayList;
+import java.util.List;
+import lombok.extern.slf4j.Slf4j;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.util.StopWatch;
+
+@Slf4j
+@ActiveProfiles("local")
+//@Disabled("성능 테스트는 필요한 경우 로컬 환경에서만 실행합니다.")
+@SpringBootTest
+class SearchServicePerformanceTest {
+
+    @Autowired
+    private SearchService searchService;
+
+    @Test
+    @DisplayName("영화 검색 간단 성능 테스트")
+    void searchMovies_performanceTest() {
+
+        String keyword = "위대한";
+        int PAGE_SIZE = 30;
+        int ITERATIONS = 10;
+
+        PageRequest pageable = PageRequest.of(0, PAGE_SIZE);
+
+        List<Long> executionTimes = new ArrayList<>();
+
+        for (int i = 1; i <= ITERATIONS; i++) {
+            StopWatch stopWatch = new StopWatch();
+            stopWatch.start();
+
+            var result = searchService.searchMovies(keyword, pageable);
+
+            stopWatch.stop();
+            long diff = stopWatch.getTotalTimeMillis();
+            executionTimes.add(diff);
+
+            log.info("[{} iteration] 반환한 영화 수 = {}, 실행 시간 = {} ms",
+                    i, result.totalElements(), diff);
+        }
+
+        // 평균 시간 계산
+        double average = executionTimes.stream()
+                .mapToLong(Long::longValue)
+                .average()
+                .orElse(0);
+
+        log.info("{}회 실행, 평균 실행 시간 = {} ms", ITERATIONS, average);
+    }
+}

--- a/src/test/java/org/example/pedia_777/domain/search/service/SearchServicePerformanceTest.java
+++ b/src/test/java/org/example/pedia_777/domain/search/service/SearchServicePerformanceTest.java
@@ -26,13 +26,14 @@ class SearchServicePerformanceTest {
 
         String keyword = "위대한";
         int PAGE_SIZE = 30;
-        int ITERATIONS = 10;
+        int TOTAL_ITERATIONS = 13;
+        int WARMUP_ITERATIONS = 3;
 
         PageRequest pageable = PageRequest.of(0, PAGE_SIZE);
 
         List<Long> executionTimes = new ArrayList<>();
 
-        for (int i = 1; i <= ITERATIONS; i++) {
+        for (int i = 1; i <= TOTAL_ITERATIONS; i++) {
             StopWatch stopWatch = new StopWatch();
             stopWatch.start();
 
@@ -40,10 +41,15 @@ class SearchServicePerformanceTest {
 
             stopWatch.stop();
             long diff = stopWatch.getTotalTimeMillis();
-            executionTimes.add(diff);
 
-            log.info("[{} iteration] 반환한 영화 수 = {}, 실행 시간 = {} ms",
-                    i, result.totalElements(), diff);
+            if (i <= WARMUP_ITERATIONS) {
+                log.info("[{} Warm-up] 검색된 영화 수 = {}, 실행 시간 = {} ms",
+                        i, result.totalElements(), diff);
+            } else {
+                executionTimes.add(diff);
+                log.info("[{} iteration] 검색된 영화 수 = {}, 실행 시간 = {} ms",
+                        i - WARMUP_ITERATIONS, result.totalElements(), diff);
+            }
         }
 
         // 평균 시간 계산
@@ -52,6 +58,9 @@ class SearchServicePerformanceTest {
                 .average()
                 .orElse(0);
 
-        log.info("{}회 실행, 평균 실행 시간 = {} ms", ITERATIONS, average);
+        log.info("{}회 실행 (Warm-up {}회 제외), 평균 실행 시간 = {} ms",
+                TOTAL_ITERATIONS - WARMUP_ITERATIONS,
+                WARMUP_ITERATIONS,
+                average);
     }
 }


### PR DESCRIPTION
## 🔗 **연관된 이슈**
> close #8 

<br>

## 📝 **작업 내용**

- Index 우선 검토 및 적용
  - %like% 검색 특성과 actors 데이터 형태로 인해, b-tree index, fulltext index, n-gram까지 유의미한 효과 x
- In-memory Cache 의존성 추가
  - Caffeine 적용
- 검색 로직에 캐시 적용
- /api/v2/search 엔드포인트 구현

<br>

## 📸 **스크린샷 (Optional)**
<img width="1847" height="590" alt="image" src="https://github.com/user-attachments/assets/6666e400-21e7-45b6-b7eb-66be73114d3c" />
<img width="1852" height="609" alt="image" src="https://github.com/user-attachments/assets/df4ac1f7-6e10-4017-a8b3-105d81d78aaf" />

- 결과 비교
  - TPS가 100가량 상승, 평균 응답 시간은 1/100로 줄어들 정도로 캐시 적용 후 성능이 압도적으로 좋아졌음
  - 다만, 로컬 환경에서 agent를 띄우고 하는 테스트의 한계인지 약 30초 후 네트워크 병목 발생으로 추정 (OS 수준에서 거절) / Spring까지 도달 자체를 못 함
    - 2025-09-29 01:17:14,323 ERROR java.util.concurrent.ExecutionException: java.net.ConnectException: Connection refused
java.net.ConnectException: Connection refused
	at org.apache.hc.core5.reactor.InternalConnectChannel.onIOEvent(InternalConnectChannel.java:64)
	at org.apache.hc.core5.reactor.InternalChannel.handleIOEvent(InternalChannel.java:51)
	at org.apache.hc.core5.reactor.SingleCoreIOReactor.processEvents(SingleCoreIOReactor.java:179)
	at org.apache.hc.core5.reactor.SingleCoreIOReactor.doExecute(SingleCoreIOReactor.java:128)
	at org.apache.hc.core5.reactor.AbstractSingleCoreIOReactor.execute(AbstractSingleCoreIOReactor.java:85)
	at org.apache.hc.core5.reactor.IOReactorWorker.run(IOReactorWorker.java:44)
  - 다만, 검색어와 pageSize, pageNumber 로 캐싱을 하는 것이 효율적으로 생각되지는 않음
  - 모든 검색 결과 자체를 캐싱 하기보다는 인기 검색어 위주로 캐싱하는 것이 좋아보이며, 인기 검색어 자체를 Redis를 저장소로 활용하여 구현하는 방향으로 생각
<br>