### PR TITLE
feat: 인기 검색어 TOP 10 조회 API 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -37,10 +37,13 @@ dependencies {
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testImplementation 'org.springframework.security:spring-security-test'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
-
-    // 테스트 코드용 Lombok
     testCompileOnly 'org.projectlombok:lombok'
     testAnnotationProcessor 'org.projectlombok:lombok'
+
+    // testcontainers
+    testImplementation 'org.springframework.boot:spring-boot-testcontainers'
+    testImplementation 'org.testcontainers:junit-jupiter'
+    testImplementation 'org.testcontainers:mysql'
 
     // bcrypt
     implementation 'at.favre.lib:bcrypt:0.10.2'

--- a/docker-compose.large.yml
+++ b/docker-compose.large.yml
@@ -36,7 +36,14 @@ services:
       - redis-data:/data
     #      - ./config/redis.conf:/usr/local/etc/redis/redis.conf #로컬의 개인 설정 파일을 컨테이너 내부로 연결
     command: redis-server --appendonly yes
-#    command: redis-server /usr/local/etc/redis/redis.conf --appendonly yes # 연결된 설정 파일을 사용하여 Redis 서버 실행
+  #    command: redis-server /usr/local/etc/redis/redis.conf --appendonly yes # 연결된 설정 파일을 사용하여 Redis 서버 실행
+
+  redis-seeder:
+    build: ./redis/init
+    depends_on:
+      - redis-db
+    environment:
+      - TZ=Asia/Seoul
 
 volumes:
   mysql-data:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -29,8 +29,15 @@ services:
       - redis-data:/data
     #      - ./config/redis.conf:/usr/local/etc/redis/redis.conf #로컬의 개인 설정 파일을 컨테이너 내부로 연결
     command: redis-server --appendonly yes
-#    command: redis-server /usr/local/etc/redis/redis.conf --appendonly yes # 연결된 설정 파일을 사용하여 Redis 서버 실행
+  #    command: redis-server /usr/local/etc/redis/redis.conf --appendonly yes # 연결된 설정 파일을 사용하여 Redis 서버 실행
 
+  redis-seeder:
+    build: ./redis/init
+    depends_on:
+      - redis-db
+    environment:
+      - TZ=Asia/Seoul
+      
 volumes:
   mysql-data:
   redis-data:

--- a/redis/init/Dockerfile
+++ b/redis/init/Dockerfile
@@ -1,0 +1,14 @@
+# 1. 가벼운 Python 이미지를 기반으로 시작
+FROM python:3.9-slim
+
+# 2. redis-cli를 설치하기 위해 redis-tools 패키지 설치
+RUN apt-get update && apt-get install -y redis-tools
+
+# 3. 컨테이너의 작업 디렉터리 설정
+WORKDIR /data
+
+# 4. 로컬의 redis/init 폴더에 있는 모든 파일(스크립트)을 이미지 안으로 복사
+COPY . .
+
+# 5. 컨테이너가 실행될 때 init-redis.sh를 실행하도록 설정
+CMD ["sh", "init-redis.sh"]

--- a/redis/init/generate_redis_data.py
+++ b/redis/init/generate_redis_data.py
@@ -1,0 +1,47 @@
+import random
+from datetime import datetime, timedelta
+
+# --- 설정값 ---
+KEY_PREFIX = "popularKeywords:"
+OUTPUT_FILENAME = "/data/dummy-data.redis"
+SEARCH_COUNT_PER_HOUR = 100
+KEYWORDS = [
+    "영웅", "도시", "보물", "그림자", "마법", "용사",
+    "김영웅", "이영웅", "박용사", "최도시", "정천사", "강바다", "이숲", "최천사"
+]
+TTL_IN_SECONDS = 7 * 24 * 60 * 60
+# --- 설정값 끝 ---
+
+def generate_commands():
+    start_time = datetime(2025, 9, 28, 0, 0)
+    end_time = datetime.now()
+
+    print(f"데이터 생성 시작: {start_time.strftime('%Y-%m-%d %H:%M')} 부터 {end_time.strftime('%Y-%m-%d %H:%M')} 까지")
+    hourly_counts = {}
+
+    current_time = start_time
+    while current_time <= end_time:
+        key = KEY_PREFIX + current_time.strftime("%Y%m%d%H")
+
+        # ✅ 디버깅을 위해 현재 어떤 키를 생성하는지 출력
+        print(f"Generating data for key: {key}")
+
+        hourly_counts[key] = {}
+        for _ in range(SEARCH_COUNT_PER_HOUR):
+            keyword = random.choice(KEYWORDS)
+            hourly_counts[key][keyword] = hourly_counts[key].get(keyword, 0) + 1
+        current_time += timedelta(hours=1)
+
+    with open(OUTPUT_FILENAME, "w", encoding="utf-8") as f:
+        f.write("FLUSHALL\n")
+        for key, counts in hourly_counts.items():
+            for keyword, score in counts.items():
+                f.write(f'ZADD "{key}" {score} "{keyword}"\n')
+            f.write(f'EXPIRE "{key}" {TTL_IN_SECONDS}\n')
+
+    print(f"\n성공! '{OUTPUT_FILENAME}' 파일이 생성되었습니다.")
+
+if __name__ == "__main__":
+    import os
+    os.makedirs(os.path.dirname(OUTPUT_FILENAME), exist_ok=True)
+    generate_commands()

--- a/redis/init/init-redis.sh
+++ b/redis/init/init-redis.sh
@@ -1,0 +1,15 @@
+#!/bin/sh
+# redis/init/init-redis.sh
+
+echo "Waiting for Redis to start..."
+sleep 10
+
+# 1. Python 스크립트를 실행하여 최신 데이터 파일 생성
+echo "Generating fresh dummy data..."
+python /data/generate_redis_data.py
+
+# 2. 생성된 파일을 redis-cli로 실행하여 데이터 주입
+echo "Seeding data into Redis..."
+redis-cli -h redis-db < /data/dummy-data.redis
+
+echo "Redis seeding completed."

--- a/src/main/java/org/example/pedia_777/common/config/CacheConfig.java
+++ b/src/main/java/org/example/pedia_777/common/config/CacheConfig.java
@@ -1,29 +1,62 @@
 package org.example.pedia_777.common.config;
 
 import com.github.benmanes.caffeine.cache.Caffeine;
+import java.time.Duration;
 import java.util.concurrent.TimeUnit;
 import org.springframework.cache.CacheManager;
 import org.springframework.cache.annotation.EnableCaching;
 import org.springframework.cache.caffeine.CaffeineCacheManager;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Primary;
+import org.springframework.data.redis.cache.RedisCacheConfiguration;
+import org.springframework.data.redis.cache.RedisCacheManager;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.serializer.GenericJackson2JsonRedisSerializer;
+import org.springframework.data.redis.serializer.RedisSerializationContext;
+import org.springframework.data.redis.serializer.StringRedisSerializer;
 
 @Configuration
 @EnableCaching
 public class CacheConfig {
 
-    @Bean
-    public CacheManager cacheManager() {
+    @Primary
+    @Bean("caffeineCacheManager")
+    public CacheManager caffeineCacheManager() {
 
         CaffeineCacheManager cacheManager = new CaffeineCacheManager();
 
         cacheManager.registerCustomCache(CacheType.MOVIE_SEARCH_NAME,
                 Caffeine.newBuilder()
-                        .recordStats()
-                        .expireAfterWrite(CacheType.MOVIE_SEARCH.getExpiredAfterWrite(), TimeUnit.MINUTES)
-                        .maximumSize(CacheType.MOVIE_SEARCH.getMaximumSize())
+                        .expireAfterWrite(CacheType.MOVIE_SEARCH.getTtl().toMinutes(), TimeUnit.MINUTES)
+                        .maximumSize(10000)
                         .build());
 
         return cacheManager;
+    }
+
+    @Bean("redisCacheManager")
+    public CacheManager redisCacheManager(RedisConnectionFactory redisConnectionFactory) {
+
+        RedisCacheConfiguration defaultConfig = RedisCacheConfiguration.defaultCacheConfig()
+                .serializeKeysWith(
+                        RedisSerializationContext.SerializationPair.fromSerializer(new StringRedisSerializer()))
+                .serializeValuesWith(RedisSerializationContext.SerializationPair.fromSerializer(
+                        new GenericJackson2JsonRedisSerializer()))
+                .entryTtl(Duration.ofMinutes(10)); // 별도로 정하지 않은 캐시의 기본 유효시간을 10분으로 설정
+
+        return RedisCacheManager.RedisCacheManagerBuilder
+                .fromConnectionFactory(redisConnectionFactory)
+                .cacheDefaults(defaultConfig)
+
+                .withCacheConfiguration(
+                        CacheType.POPULAR_KEYWORDS_NAME, // "popularKeywords"
+                        defaultConfig.entryTtl(CacheType.POPULAR_KEYWORDS.getTtl())
+                )
+                .withCacheConfiguration(
+                        CacheType.MOVIE_SEARCH.getCacheName(), // "movieSearch"
+                        defaultConfig.entryTtl(CacheType.MOVIE_SEARCH.getTtl())
+                )
+                .build();
     }
 }

--- a/src/main/java/org/example/pedia_777/common/config/CacheType.java
+++ b/src/main/java/org/example/pedia_777/common/config/CacheType.java
@@ -1,5 +1,6 @@
 package org.example.pedia_777.common.config;
 
+import java.time.Duration;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 
@@ -7,11 +8,12 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public enum CacheType {
 
-    MOVIE_SEARCH("movieSearch", 10, 5000); // 10분, 5,000개
+    MOVIE_SEARCH("movieSearch", Duration.ofMinutes(10)), // 10분
+    POPULAR_KEYWORDS("popularKeywords", Duration.ofMinutes(120)); // 2시간
 
     public static final String MOVIE_SEARCH_NAME = "movieSearch";
+    public static final String POPULAR_KEYWORDS_NAME = "popularKeywords";
 
     private final String cacheName;
-    private final long expiredAfterWrite;
-    private final int maximumSize;
+    private final Duration ttl;
 }

--- a/src/main/java/org/example/pedia_777/domain/search/controller/SearchController.java
+++ b/src/main/java/org/example/pedia_777/domain/search/controller/SearchController.java
@@ -1,11 +1,14 @@
 package org.example.pedia_777.domain.search.controller;
 
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.example.pedia_777.common.code.CommonSuccessCode;
 import org.example.pedia_777.common.dto.GlobalApiResponse;
 import org.example.pedia_777.common.dto.PageResponse;
 import org.example.pedia_777.common.util.ResponseHelper;
 import org.example.pedia_777.domain.search.dto.response.MovieSearchResponse;
+import org.example.pedia_777.domain.search.dto.response.PopularKeywordResponse;
+import org.example.pedia_777.domain.search.service.PopularSearchService;
 import org.example.pedia_777.domain.search.service.SearchService;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.web.PageableDefault;
@@ -19,6 +22,7 @@ import org.springframework.web.bind.annotation.RestController;
 public class SearchController {
 
     private final SearchService searchService;
+    private final PopularSearchService popularSearchService;
 
     @GetMapping("/api/v1/search")
     public ResponseEntity<GlobalApiResponse<PageResponse<MovieSearchResponse>>> searchMovies(
@@ -36,5 +40,13 @@ public class SearchController {
 
         return ResponseHelper.success(CommonSuccessCode.REQUEST_SUCCESS,
                 searchService.searchMoviesWithLocalCache(keyword, pageable));
+    }
+
+    @GetMapping("/api/v1/search/popular")
+    public ResponseEntity<GlobalApiResponse<List<PopularKeywordResponse>>> getPopularKeywords() {
+
+        // TODO 현재는 UI 기획대로 바로 이전 시간대 데이터만 조회하도록 구현, 시간대 선택 가능하도록 RequestParam 적용 가능
+        return ResponseHelper.success(CommonSuccessCode.REQUEST_SUCCESS,
+                popularSearchService.getPopularKeywordsOfPreviousHour());
     }
 }

--- a/src/main/java/org/example/pedia_777/domain/search/dto/response/PopularKeywordResponse.java
+++ b/src/main/java/org/example/pedia_777/domain/search/dto/response/PopularKeywordResponse.java
@@ -1,0 +1,10 @@
+package org.example.pedia_777.domain.search.dto.response;
+
+public record PopularKeywordResponse(
+        int rank,
+        String keyword) {
+
+    public static PopularKeywordResponse of(int rank, String keyword) {
+        return new PopularKeywordResponse(rank, keyword);
+    }
+}

--- a/src/main/java/org/example/pedia_777/domain/search/service/PopularSearchService.java
+++ b/src/main/java/org/example/pedia_777/domain/search/service/PopularSearchService.java
@@ -1,0 +1,71 @@
+package org.example.pedia_777.domain.search.service;
+
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+import java.time.temporal.ChronoUnit;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+import java.util.Set;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.example.pedia_777.common.config.CacheType;
+import org.example.pedia_777.domain.search.dto.response.PopularKeywordResponse;
+import org.springframework.cache.annotation.Cacheable;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.stereotype.Service;
+
+@Slf4j
+@RequiredArgsConstructor
+@Service
+public class PopularSearchService {
+
+    private static final String KEY_PREFIX = "popularKeywords:";  // Sorted Set의 Key
+    private final RedisTemplate<String, String> redisTemplate;
+
+
+    // ZINCRBY을 이용하여 검색어의 점수를 1 증가시킴, 검색 함수에 사용
+    public void incrementSearchKeyword(String keyword) {
+
+        String currentKey = getCurrentHourKey();
+        redisTemplate.opsForZSet().incrementScore(currentKey, keyword, 1);
+    }
+
+    // 이전 시간대(정각 ~ 정각 사이)의 인기 검색어 10개 조회
+    @Cacheable(value = CacheType.POPULAR_KEYWORDS_NAME, cacheManager = "redisCacheManager",
+            key = "#root.methodName + ':' + #root.target.getPreviousHourKey()")
+    public List<PopularKeywordResponse> getPopularKeywordsOfPreviousHour() {
+
+        // 이전 시간대의 Key를 가져와서 ZREVRANGE 실행
+        String previousKey = getPreviousHourKey();
+        Set<String> topKeywords = redisTemplate.opsForZSet().reverseRange(previousKey, 0, 9);
+
+        log.debug(Objects.requireNonNull(topKeywords).toString());
+
+        List<String> keywordList = new ArrayList<>(topKeywords);
+        return IntStream.range(0, keywordList.size())
+                .mapToObj(i -> PopularKeywordResponse.of(i + 1, keywordList.get(i)))
+                .collect(Collectors.toList());
+    }
+
+
+    // 현재 시간을 기준으로 Key를 생성 (e.g.: 4시 1분, 4시 30분 -> 4시 "popularKeywords:2025092804")
+    private String getCurrentHourKey() {
+
+        return KEY_PREFIX + LocalDateTime.now()
+                .truncatedTo(ChronoUnit.HOURS)
+                .format(DateTimeFormatter.ofPattern("yyyyMMddHH"));
+    }
+
+    // 조회를 위해 이전 시간대를 기준으로 Key를 생성 (e.g.: 4시 1분이면 "popularKeywords:2025092803" 반환)
+    public String getPreviousHourKey() {
+
+        // 현재 시간을 시간 단위로 절삭 후, 1시간을 뺌
+        return KEY_PREFIX + LocalDateTime.now()
+                .truncatedTo(ChronoUnit.HOURS)
+                .minusHours(1)
+                .format(DateTimeFormatter.ofPattern("yyyyMMddHH"));
+    }
+}

--- a/src/test/java/org/example/pedia_777/domain/search/service/PopularSearchServiceTest.java
+++ b/src/test/java/org/example/pedia_777/domain/search/service/PopularSearchServiceTest.java
@@ -1,0 +1,144 @@
+package org.example.pedia_777.domain.search.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+import java.time.temporal.ChronoUnit;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import org.example.pedia_777.domain.search.dto.response.PopularKeywordResponse;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.testcontainers.service.connection.ServiceConnection;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.test.context.ActiveProfiles;
+import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.containers.MySQLContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+
+@Testcontainers
+@SpringBootTest
+@ActiveProfiles("test")
+class PopularSearchServiceTest {
+
+    // @Container와 @ServiceConnection으로 사용될 컨테이너 정의
+    @Container
+    @ServiceConnection
+    private static final MySQLContainer<?> mysqlContainer = new MySQLContainer<>("mysql:8.0");
+
+    @Container
+    @ServiceConnection
+    private static final GenericContainer<?> redisContainer = new GenericContainer<>("redis:7.2-alpine")
+            .withExposedPorts(6379);
+
+    @Autowired
+    private PopularSearchService popularSearchService;
+
+    @Autowired
+    private RedisTemplate<String, String> redisTemplate;
+
+    @BeforeEach
+    void setUp() {
+        Objects.requireNonNull(redisTemplate.getConnectionFactory())
+                .getConnection()
+                .serverCommands()
+                .flushDb();
+    }
+
+    @Test
+    @DisplayName("검색어 카운트가 정상적으로 1씩 증가한다")
+    void incrementSearchKeyword_Success() {
+
+        // given
+        String keyword = "Spring";
+        String currentHourKey = getCurrentHourKey();
+
+        // when
+        popularSearchService.incrementSearchKeyword(keyword);
+        popularSearchService.incrementSearchKeyword(keyword);
+        popularSearchService.incrementSearchKeyword(keyword);
+        popularSearchService.incrementSearchKeyword(keyword);
+        popularSearchService.incrementSearchKeyword(keyword);
+
+        // 다른 키워드도 한 번 호출
+        popularSearchService.incrementSearchKeyword("Java");
+
+        // then
+        // Redis에 저장된 점수 검증
+        Double springScore = redisTemplate.opsForZSet().score(currentHourKey, "Spring");
+        Double javaScore = redisTemplate.opsForZSet().score(currentHourKey, "Java");
+        Double nonExistentScore = redisTemplate.opsForZSet().score(currentHourKey, "Docker");
+
+        assertThat(springScore).isEqualTo(5.0);
+        assertThat(javaScore).isEqualTo(1.0);
+        assertThat(nonExistentScore).isNull(); // 호출된 적 없는 키워드는 점수가 없음
+    }
+
+    @Test
+    @DisplayName("인기 검색어 순위 조회를 하면 이전 시간대에서 score 높은 순으로 반환된다")
+    void getPopularKeywords_Success() {
+
+        // given
+        // 이전 시간대의 키를 직접 생성하여 12개의 테스트 데이터를 준비
+        String previousHourKey = getPreviousHourKey();
+
+        Map<String, Double> keywordScores = Map.ofEntries(
+                Map.entry("Java", 85.0),
+                Map.entry("Spring", 100.0),
+                Map.entry("Docker", 70.0),
+                Map.entry("JPA", 90.0),
+                Map.entry("QueryDSL", 75.0),
+                Map.entry("MySQL", 60.0),
+                Map.entry("AWS", 55.0),
+                Map.entry("Redis", 95.0),
+                Map.entry("Nginx", 50.0),
+                Map.entry("Kotlin", 88.0),
+                Map.entry("C++", 20.0),
+                Map.entry("Python", 40.0)
+        );
+
+        keywordScores.forEach((keyword, score) ->
+                redisTemplate.opsForZSet().add(previousHourKey, keyword, score)
+        );
+
+        // when
+        List<PopularKeywordResponse> popularKeywords = popularSearchService.getPopularKeywordsOfPreviousHour();
+
+        // then
+        assertThat(popularKeywords).hasSize(10);
+
+        assertThat(popularKeywords).extracting(PopularKeywordResponse::rank)
+                .containsExactly(1, 2, 3, 4, 5, 6, 7, 8, 9, 10);
+
+        // 높은 순 정렬 맞는지 검증
+        assertThat(popularKeywords).extracting(PopularKeywordResponse::keyword)
+                .containsExactly(
+                        "Spring",   // 100.0
+                        "Redis",    // 95.0
+                        "JPA",      // 90.0
+                        "Kotlin",   // 88.0
+                        "Java",     // 85.0
+                        "QueryDSL", // 75.0
+                        "Docker",   // 70.0
+                        "MySQL",    // 60.0
+                        "AWS",      // 55.0
+                        "Nginx"     // 50.0
+                );
+    }
+
+    private String getCurrentHourKey() {
+        LocalDateTime now = LocalDateTime.now().truncatedTo(ChronoUnit.HOURS);
+        return "popularKeywords:" + now.format(DateTimeFormatter.ofPattern("yyyyMMddHH"));
+    }
+
+    private String getPreviousHourKey() {
+        LocalDateTime previousHour = LocalDateTime.now().truncatedTo(ChronoUnit.HOURS).minusHours(1);
+        return "popularKeywords:" + previousHour.format(DateTimeFormatter.ofPattern("yyyyMMddHH"));
+    }
+}

--- a/src/test/resources/application-test.yml
+++ b/src/test/resources/application-test.yml
@@ -1,0 +1,15 @@
+spring:
+  jpa:
+    hibernate:
+      ddl-auto: create-drop
+    properties:
+      hibernate:
+        show_sql: true
+
+  sql:
+    init:
+      mode: never
+
+jwt:
+  secret:
+    key: dummysecretkeydummysecretkeydummysecretkeydummysecretkeydummysecretkeydummysecretkey


### PR DESCRIPTION
## 🔗 **연관된 이슈**
> close #10 

<br>

## 📝 **작업 내용**

- 이전 시간대의 인기 검색어 TOP 10을 조회할 수 있도록 합니다.
- 3시 1분에 조회하면 2시~3시 사이의 인기 검색어를 조회할 수 있습니다.

## 📝 상세 작업 내용 (To-Do List)
- [x] 기존에 존재하는 Caffeine 캐시 매니저와 분리하여 Redis 캐시 매니저 추가
- [x] Redis sorted Set을 이용하여 검색 API 호출 시 사용되는 인기 검색어 추가 로직 구현
- [x] 인기 검색어 조회 로직 구현
- [x] 인기 검색어 조회 로직에 캐시 적용 (2시간)
- [x] 엔드포인트 구현

## ✅ 참고 사항
> (선택 사항) 관련 Lofi-wireframe, 참고 자료, 논의 내용 등을 추가해주세요.

- 검색 API v3에서 Redis 검색 API에 대한 캐시을 Redis로 전환하면서, 최종 검색 아키텍처 개선 예정
  - [x] **인기 검색어 조회 API**
    - Redis Sorted Set을 이용하여 검색 로직 자체를 Redis로 구현
    - 인기 검색어 조회 API 자체에는 Redis 캐시 적용 
    - **이번 PR을 통해 구현**
    - 차후 기간별 조회, 일정기간 이후 MySQL로 백업하도록 하는 기능 추가 가능
  - [x] **영화 검색 API**
    - 인기 검색어로 검색이 들어왔을 때만, 그 결과를 캐시에 저장하고 캐시를 통해 반환하도록 개선 예정
    - 다음 API v3에서 Redis 전환과 함께 적용
    - 오늘 구현 예정
  - [x] **주간/일간 영화 TOP10 조회 API**
     - 인기 검색어 조회와 굉장히 유사
     - 내일 구현 예정
     - 과제에서 요구하는 검색 API와 인기 검색어 API 가 이미 있으므로 우선순위에 따라 변동 가능

---

- 레디스 더미 데이터 관련
  - 9월 28일 00시부터 docker compose 실행 시점 이전 시간대까지의 더미 인기 검색어 데이터 생성에 필요한 파일들이 포함되어 있습니다.
  - 기존 명령어대로 docker compose 실행하면 됩니다. 그러면 DB 툴을 통해 Docker로 띄워진 Redis 연결하시면 확인하실 수 있습니다.
  - Redis는 사용자명, 비밀번호 없습니다.


     
## 📸 **스크린샷 (Optional)**

<br>