### PR TITLE
feat: 영화 검색어 조회 v3 (v2 with Redis) API 구현 및 인기 검색어 Top 10 목록의 대상만 캐시하도록 구현

### DIFF
--- a/src/main/java/org/example/pedia_777/common/config/CacheConfig.java
+++ b/src/main/java/org/example/pedia_777/common/config/CacheConfig.java
@@ -1,10 +1,14 @@
 package org.example.pedia_777.common.config;
 
+import com.github.benmanes.caffeine.cache.Caffeine;
 import java.time.Duration;
+import java.util.concurrent.TimeUnit;
 import org.springframework.cache.CacheManager;
 import org.springframework.cache.annotation.EnableCaching;
+import org.springframework.cache.caffeine.CaffeineCacheManager;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Primary;
 import org.springframework.data.redis.cache.RedisCacheConfiguration;
 import org.springframework.data.redis.cache.RedisCacheManager;
 import org.springframework.data.redis.connection.RedisConnectionFactory;
@@ -16,6 +20,20 @@ import org.springframework.data.redis.serializer.StringRedisSerializer;
 @EnableCaching
 public class CacheConfig {
 
+    @Primary
+    @Bean("caffeineCacheManager")
+    public CacheManager caffeineCacheManager() {
+        CaffeineCacheManager cacheManager = new CaffeineCacheManager();
+
+        cacheManager.registerCustomCache(CacheType.IS_POPULAR_KEYWORD_NAME, // 키워드의 인기 검색어 여부
+                Caffeine.newBuilder()
+                        .expireAfterWrite(CacheType.IS_POPULAR_KEYWORD.getTtl().toMinutes(), TimeUnit.MINUTES)
+                        .maximumSize(1000)
+                        .build());
+
+        return cacheManager;
+    }
+
     @Bean("redisCacheManager")
     public CacheManager redisCacheManager(RedisConnectionFactory redisConnectionFactory) {
 
@@ -24,7 +42,7 @@ public class CacheConfig {
                         RedisSerializationContext.SerializationPair.fromSerializer(new StringRedisSerializer()))
                 .serializeValuesWith(RedisSerializationContext.SerializationPair.fromSerializer(
                         new GenericJackson2JsonRedisSerializer()))
-                .entryTtl(Duration.ofMinutes(10)); // 별도로 정하지 않은 캐시의 기본 유효시간을 10분으로 설정
+                .entryTtl(Duration.ofMinutes(10));
 
         return RedisCacheManager.RedisCacheManagerBuilder
                 .fromConnectionFactory(redisConnectionFactory)

--- a/src/main/java/org/example/pedia_777/common/config/CacheConfig.java
+++ b/src/main/java/org/example/pedia_777/common/config/CacheConfig.java
@@ -1,14 +1,10 @@
 package org.example.pedia_777.common.config;
 
-import com.github.benmanes.caffeine.cache.Caffeine;
 import java.time.Duration;
-import java.util.concurrent.TimeUnit;
 import org.springframework.cache.CacheManager;
 import org.springframework.cache.annotation.EnableCaching;
-import org.springframework.cache.caffeine.CaffeineCacheManager;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.context.annotation.Primary;
 import org.springframework.data.redis.cache.RedisCacheConfiguration;
 import org.springframework.data.redis.cache.RedisCacheManager;
 import org.springframework.data.redis.connection.RedisConnectionFactory;
@@ -19,20 +15,6 @@ import org.springframework.data.redis.serializer.StringRedisSerializer;
 @Configuration
 @EnableCaching
 public class CacheConfig {
-
-    @Primary
-    @Bean("caffeineCacheManager")
-    public CacheManager caffeineCacheManager() {
-        CaffeineCacheManager cacheManager = new CaffeineCacheManager();
-
-        cacheManager.registerCustomCache(CacheType.IS_POPULAR_KEYWORD_NAME, // 키워드의 인기 검색어 여부
-                Caffeine.newBuilder()
-                        .expireAfterWrite(CacheType.IS_POPULAR_KEYWORD.getTtl().toMinutes(), TimeUnit.MINUTES)
-                        .maximumSize(1000)
-                        .build());
-
-        return cacheManager;
-    }
 
     @Bean("redisCacheManager")
     public CacheManager redisCacheManager(RedisConnectionFactory redisConnectionFactory) {
@@ -49,12 +31,16 @@ public class CacheConfig {
                 .cacheDefaults(defaultConfig)
 
                 .withCacheConfiguration(
-                        CacheType.POPULAR_KEYWORDS_NAME, // "popularKeywords"
+                        CacheType.NAME_POPULAR_KEYWORDS, // "popularKeywords"
                         defaultConfig.entryTtl(CacheType.POPULAR_KEYWORDS.getTtl())
                 )
                 .withCacheConfiguration(
-                        CacheType.MOVIE_SEARCH.getCacheName(), // "movieSearch"
-                        defaultConfig.entryTtl(CacheType.MOVIE_SEARCH.getTtl())
+                        CacheType.NAME_MOVIE_SEARCH_CURRENT_POPULAR, // "movieSearchCurrentPopular"
+                        defaultConfig.entryTtl(CacheType.MOVIE_SEARCH_CURRENT_POPULAR.getTtl())
+                )
+                .withCacheConfiguration(
+                        CacheType.NAME_MOVIE_SEARCH_PREV_POPULAR, // "movieSearchPrevPopular"
+                        defaultConfig.entryTtl(CacheType.MOVIE_SEARCH_PREV_POPULAR.getTtl())
                 )
                 .build();
     }

--- a/src/main/java/org/example/pedia_777/common/config/CacheConfig.java
+++ b/src/main/java/org/example/pedia_777/common/config/CacheConfig.java
@@ -1,14 +1,10 @@
 package org.example.pedia_777.common.config;
 
-import com.github.benmanes.caffeine.cache.Caffeine;
 import java.time.Duration;
-import java.util.concurrent.TimeUnit;
 import org.springframework.cache.CacheManager;
 import org.springframework.cache.annotation.EnableCaching;
-import org.springframework.cache.caffeine.CaffeineCacheManager;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.context.annotation.Primary;
 import org.springframework.data.redis.cache.RedisCacheConfiguration;
 import org.springframework.data.redis.cache.RedisCacheManager;
 import org.springframework.data.redis.connection.RedisConnectionFactory;
@@ -19,21 +15,6 @@ import org.springframework.data.redis.serializer.StringRedisSerializer;
 @Configuration
 @EnableCaching
 public class CacheConfig {
-
-    @Primary
-    @Bean("caffeineCacheManager")
-    public CacheManager caffeineCacheManager() {
-
-        CaffeineCacheManager cacheManager = new CaffeineCacheManager();
-
-        cacheManager.registerCustomCache(CacheType.MOVIE_SEARCH_NAME,
-                Caffeine.newBuilder()
-                        .expireAfterWrite(CacheType.MOVIE_SEARCH.getTtl().toMinutes(), TimeUnit.MINUTES)
-                        .maximumSize(10000)
-                        .build());
-
-        return cacheManager;
-    }
 
     @Bean("redisCacheManager")
     public CacheManager redisCacheManager(RedisConnectionFactory redisConnectionFactory) {

--- a/src/main/java/org/example/pedia_777/common/config/CacheType.java
+++ b/src/main/java/org/example/pedia_777/common/config/CacheType.java
@@ -8,13 +8,13 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public enum CacheType {
 
-    MOVIE_SEARCH("movieSearch", Duration.ofMinutes(10)), // 10분
-    POPULAR_KEYWORDS("popularKeywords", Duration.ofMinutes(120)), // 2시간
-    IS_POPULAR_KEYWORD("isPopularKeyword", Duration.ofMinutes(1)); // 1분
+    MOVIE_SEARCH_CURRENT_POPULAR("movieSearchCurrentPopular", Duration.ofMinutes(5)), // 5분
+    MOVIE_SEARCH_PREV_POPULAR("movieSearchPrevPopular", Duration.ofMinutes(120)), // 2시간
+    POPULAR_KEYWORDS("popularKeywords", Duration.ofMinutes(120)); // 2시간
 
-    public static final String MOVIE_SEARCH_NAME = "movieSearch";
-    public static final String POPULAR_KEYWORDS_NAME = "popularKeywords";
-    public static final String IS_POPULAR_KEYWORD_NAME = "isPopularKeyword";
+    public static final String NAME_MOVIE_SEARCH_CURRENT_POPULAR = "movieSearchCurrentPopular";
+    public static final String NAME_MOVIE_SEARCH_PREV_POPULAR = "movieSearchPrevPopular";
+    public static final String NAME_POPULAR_KEYWORDS = "popularKeywords";
 
     private final String cacheName;
     private final Duration ttl;

--- a/src/main/java/org/example/pedia_777/common/config/CacheType.java
+++ b/src/main/java/org/example/pedia_777/common/config/CacheType.java
@@ -9,10 +9,12 @@ import lombok.RequiredArgsConstructor;
 public enum CacheType {
 
     MOVIE_SEARCH("movieSearch", Duration.ofMinutes(10)), // 10분
-    POPULAR_KEYWORDS("popularKeywords", Duration.ofMinutes(120)); // 2시간
+    POPULAR_KEYWORDS("popularKeywords", Duration.ofMinutes(120)), // 2시간
+    IS_POPULAR_KEYWORD("isPopularKeyword", Duration.ofMinutes(1)); // 1분
 
     public static final String MOVIE_SEARCH_NAME = "movieSearch";
     public static final String POPULAR_KEYWORDS_NAME = "popularKeywords";
+    public static final String IS_POPULAR_KEYWORD_NAME = "isPopularKeyword";
 
     private final String cacheName;
     private final Duration ttl;

--- a/src/main/java/org/example/pedia_777/domain/movie/entity/Movie.java
+++ b/src/main/java/org/example/pedia_777/domain/movie/entity/Movie.java
@@ -4,6 +4,8 @@ import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
+import jakarta.persistence.Index;
+import jakarta.persistence.Table;
 import jakarta.persistence.Temporal;
 import jakarta.persistence.TemporalType;
 import java.time.LocalDate;
@@ -17,6 +19,9 @@ import org.springframework.data.annotation.LastModifiedDate;
 @Getter
 @NoArgsConstructor(access = lombok.AccessLevel.PROTECTED)
 @Entity
+@Table(indexes = {
+        @Index(name = "idx_movie_release_date", columnList = "releaseDate")
+})
 public class Movie extends BaseTimeEntity {
 
     @Id

--- a/src/main/java/org/example/pedia_777/domain/movie/repository/MovieRepository.java
+++ b/src/main/java/org/example/pedia_777/domain/movie/repository/MovieRepository.java
@@ -1,31 +1,7 @@
 package org.example.pedia_777.domain.movie.repository;
 
 import org.example.pedia_777.domain.movie.entity.Movie;
-import org.example.pedia_777.domain.search.dto.response.MovieSearchProjection;
-import org.springframework.data.domain.Page;
-import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.data.jpa.repository.Query;
-import org.springframework.data.repository.query.Param;
 
 public interface MovieRepository extends JpaRepository<Movie, Long>, MovieSearchRepository {
-
-    @Query(value = """
-            SELECT m.id, m.title, m.director, m.actors, m.poster_url,
-                   AVG(r.star) AS avgStar,
-                   COUNT(DISTINCT r.id) AS reviewCount,
-                   COUNT(DISTINCT f.id) AS favoriteCount
-            FROM movie m
-            LEFT JOIN review r ON r.movies_id = m.id AND r.deleted_at IS NULL
-            LEFT JOIN favorite f ON f.movie_id = m.id
-            WHERE MATCH(m.title, m.director, m.actors) AGAINST (:keyword IN BOOLEAN MODE)       
-            GROUP BY m.id
-            """,
-            countQuery = """
-                    SELECT COUNT(*) 
-                    FROM movie m 
-                    WHERE MATCH(m.title, m.director, m.actors) AGAINST (:keyword IN BOOLEAN MODE)
-                    """,
-            nativeQuery = true)
-    Page<MovieSearchProjection> searchMoviesNative(@Param("keyword") String keyword, Pageable pageable);
 }

--- a/src/main/java/org/example/pedia_777/domain/movie/repository/MovieRepository.java
+++ b/src/main/java/org/example/pedia_777/domain/movie/repository/MovieRepository.java
@@ -8,7 +8,7 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
-public interface MovieRepository extends JpaRepository<Movie, Long>, MovieRepositoryCustom {
+public interface MovieRepository extends JpaRepository<Movie, Long>, MovieSearchRepository {
 
     @Query(value = """
             SELECT m.id, m.title, m.director, m.actors, m.poster_url,

--- a/src/main/java/org/example/pedia_777/domain/movie/repository/MovieSearchRepository.java
+++ b/src/main/java/org/example/pedia_777/domain/movie/repository/MovieSearchRepository.java
@@ -4,7 +4,7 @@ import org.example.pedia_777.domain.search.dto.response.MovieSearchProjection;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 
-public interface MovieRepositoryCustom {
+public interface MovieSearchRepository {
 
     Page<MovieSearchProjection> searchMovies(String keyword, Pageable pageable);
 

--- a/src/main/java/org/example/pedia_777/domain/movie/repository/MovieSearchRepositoryImpl.java
+++ b/src/main/java/org/example/pedia_777/domain/movie/repository/MovieSearchRepositoryImpl.java
@@ -14,7 +14,7 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.data.support.PageableExecutionUtils;
 
 @RequiredArgsConstructor
-public class MovieRepositoryCustomImpl implements MovieRepositoryCustom {
+public class MovieSearchRepositoryImpl implements MovieSearchRepository {
 
     private final JPAQueryFactory queryFactory;
 

--- a/src/main/java/org/example/pedia_777/domain/movie/service/MovieService.java
+++ b/src/main/java/org/example/pedia_777/domain/movie/service/MovieService.java
@@ -34,11 +34,5 @@ public class MovieService implements MovieServiceApi {
     public Page<MovieSearchResponse> searchMovies(String keyword, Pageable pageable) {
         return movieRepository.searchMovies(keyword, pageable)
                 .map(MovieSearchResponse::from);
-
-        // fulltext index 테스트를 위한 코드, 삭제 예정
-//        String fullTextKeyword = keyword;
-//        String fullTextKeyword = "+" + keyword + "*";
-//        return movieRepository.searchMoviesNative(fullTextKeyword, pageable)
-//                .map(MovieSearchResponse::from);
     }
 }

--- a/src/main/java/org/example/pedia_777/domain/search/controller/SearchController.java
+++ b/src/main/java/org/example/pedia_777/domain/search/controller/SearchController.java
@@ -24,6 +24,7 @@ public class SearchController {
     private final SearchService searchService;
     private final PopularSearchService popularSearchService;
 
+    // v1: DB 조회
     @GetMapping("/api/v1/search")
     public ResponseEntity<GlobalApiResponse<PageResponse<MovieSearchResponse>>> searchMovies(
             @RequestParam String keyword,
@@ -33,19 +34,19 @@ public class SearchController {
                 searchService.searchMovies(keyword, pageable));
     }
 
+    // v2: Redis 적용
     @GetMapping("/api/v2/search")
     public ResponseEntity<GlobalApiResponse<PageResponse<MovieSearchResponse>>> searchMoviesWithLocalCache(
             @RequestParam String keyword,
             @PageableDefault(size = 10) Pageable pageable) {
 
         return ResponseHelper.success(CommonSuccessCode.REQUEST_SUCCESS,
-                searchService.searchMoviesWithLocalCache(keyword, pageable));
+                searchService.searchMoviesWithCache(keyword, pageable));
     }
 
     @GetMapping("/api/v1/search/popular")
     public ResponseEntity<GlobalApiResponse<List<PopularKeywordResponse>>> getPopularKeywords() {
 
-        // TODO 현재는 UI 기획대로 바로 이전 시간대 데이터만 조회하도록 구현, 시간대 선택 가능하도록 RequestParam 적용 가능
         return ResponseHelper.success(CommonSuccessCode.REQUEST_SUCCESS,
                 popularSearchService.getPopularKeywordsOfPreviousHour());
     }

--- a/src/main/java/org/example/pedia_777/domain/search/controller/SearchController.java
+++ b/src/main/java/org/example/pedia_777/domain/search/controller/SearchController.java
@@ -30,6 +30,7 @@ public class SearchController {
             @RequestParam String keyword,
             @PageableDefault(size = 10) Pageable pageable) {
 
+        popularSearchService.incrementSearchKeyword(keyword);
         return ResponseHelper.success(CommonSuccessCode.REQUEST_SUCCESS,
                 searchService.searchMovies(keyword, pageable));
     }
@@ -40,6 +41,7 @@ public class SearchController {
             @RequestParam String keyword,
             @PageableDefault(size = 10) Pageable pageable) {
 
+        popularSearchService.incrementSearchKeyword(keyword);
         return ResponseHelper.success(CommonSuccessCode.REQUEST_SUCCESS,
                 searchService.searchMoviesWithCache(keyword, pageable));
     }

--- a/src/main/java/org/example/pedia_777/domain/search/entity/PopularType.java
+++ b/src/main/java/org/example/pedia_777/domain/search/entity/PopularType.java
@@ -1,0 +1,7 @@
+package org.example.pedia_777.domain.search.entity;
+
+public enum PopularType {
+    PREVIOUS, // 이전 시간대 인기 검색어
+    CURRENT,  // 현재 시간대 인기 검색어
+    NONE      // 인기 검색어 아님
+}

--- a/src/main/java/org/example/pedia_777/domain/search/service/SearchCacheService.java
+++ b/src/main/java/org/example/pedia_777/domain/search/service/SearchCacheService.java
@@ -1,0 +1,39 @@
+package org.example.pedia_777.domain.search.service;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.example.pedia_777.common.config.CacheType;
+import org.example.pedia_777.common.dto.PageResponse;
+import org.example.pedia_777.domain.movie.service.MovieService;
+import org.example.pedia_777.domain.search.dto.response.MovieSearchResponse;
+import org.springframework.cache.annotation.Cacheable;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class SearchCacheService {
+
+    // AOP self-invocation 문제 해결을 위해 별도 서비스로 분리
+
+    private final MovieService movieService;
+
+    // 과거 인기 검색어의 포함된 키워드의 "결과"를 2시간 캐싱
+    @Cacheable(cacheNames = CacheType.NAME_MOVIE_SEARCH_PREV_POPULAR, cacheManager = "redisCacheManager",
+            key = "'previous:' + #keyword.trim().toLowerCase() + ':' + #pageable.pageNumber + ':' + #pageable.pageSize",
+            sync = true)
+    public PageResponse<MovieSearchResponse> searchMoviesForPreviousPopularKeywords(String keyword, Pageable pageable) {
+
+        return PageResponse.from(movieService.searchMovies(keyword, pageable));
+    }
+
+    // 현재 인기 검색어의 포함된 키워드의 "결과"를 5분 캐싱
+    @Cacheable(cacheNames = CacheType.NAME_MOVIE_SEARCH_CURRENT_POPULAR, cacheManager = "redisCacheManager",
+            key = "'current:' + #keyword.trim().toLowerCase() + ':' + #pageable.pageNumber + ':' + #pageable.pageSize",
+            sync = true)
+    public PageResponse<MovieSearchResponse> searchMoviesForCurrentPopularKeywords(String keyword, Pageable pageable) {
+
+        return PageResponse.from(movieService.searchMovies(keyword, pageable));
+    }
+}

--- a/src/main/java/org/example/pedia_777/domain/search/service/SearchService.java
+++ b/src/main/java/org/example/pedia_777/domain/search/service/SearchService.java
@@ -20,7 +20,6 @@ public class SearchService {
 
     public PageResponse<MovieSearchResponse> searchMovies(String keyword, Pageable pageable) {
 
-        popularSearchService.incrementSearchKeyword(keyword);
         return PageResponse.from(movieService.searchMovies(keyword, pageable));
     }
 
@@ -34,7 +33,6 @@ public class SearchService {
         log.debug("[SearchService] searchMoviesWithCache Cache miss: keyword: {}, pageSize: {}, pageNumber: {}",
                 keyword, pageable.getPageSize(), pageable.getPageNumber());
 
-        popularSearchService.incrementSearchKeyword(keyword);
         return PageResponse.from(movieService.searchMovies(keyword, pageable));
     }
 

--- a/src/main/java/org/example/pedia_777/domain/search/service/SearchService.java
+++ b/src/main/java/org/example/pedia_777/domain/search/service/SearchService.java
@@ -25,7 +25,7 @@ public class SearchService {
     }
 
     @Cacheable(
-            cacheNames = CacheType.MOVIE_SEARCH_NAME, cacheManager = "caffeineCacheManager",
+            cacheNames = CacheType.MOVIE_SEARCH_NAME, cacheManager = "redisCacheManager",
             key = "'search:' + #keyword.trim().toLowerCase() + ':' + #pageable.pageNumber + ':' + #pageable.pageSize",
             condition = "#keyword != null && #keyword.trim().length() <= 30 && #pageable.pageSize <= 30 && #pageable.pageNumber <= 3",
             unless = "#result == null || #result.content.isEmpty()")

--- a/src/main/java/org/example/pedia_777/domain/search/service/SearchService.java
+++ b/src/main/java/org/example/pedia_777/domain/search/service/SearchService.java
@@ -27,7 +27,7 @@ public class SearchService {
     @Cacheable(
             cacheNames = CacheType.MOVIE_SEARCH_NAME, cacheManager = "redisCacheManager",
             key = "'search:' + #keyword.trim().toLowerCase() + ':' + #pageable.pageNumber + ':' + #pageable.pageSize",
-            condition = "#keyword != null && #keyword.trim().length() <= 30 && #pageable.pageSize <= 30 && #pageable.pageNumber <= 3",
+            condition = "@popularSearchService.isPopular(#keyword)",
             unless = "#result == null || #result.content.isEmpty()")
     public PageResponse<MovieSearchResponse> searchMoviesWithCache(String keyword, Pageable pageable) {
 

--- a/src/main/java/org/example/pedia_777/domain/search/service/SearchService.java
+++ b/src/main/java/org/example/pedia_777/domain/search/service/SearchService.java
@@ -2,11 +2,10 @@ package org.example.pedia_777.domain.search.service;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.example.pedia_777.common.config.CacheType;
 import org.example.pedia_777.common.dto.PageResponse;
 import org.example.pedia_777.domain.movie.service.MovieService;
 import org.example.pedia_777.domain.search.dto.response.MovieSearchResponse;
-import org.springframework.cache.annotation.Cacheable;
+import org.example.pedia_777.domain.search.entity.PopularType;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 
@@ -17,23 +16,31 @@ public class SearchService {
 
     private final MovieService movieService;
     private final PopularSearchService popularSearchService;
+    private final SearchCacheService searchCacheService;
 
     public PageResponse<MovieSearchResponse> searchMovies(String keyword, Pageable pageable) {
 
         return PageResponse.from(movieService.searchMovies(keyword, pageable));
     }
 
-    @Cacheable(
-            cacheNames = CacheType.MOVIE_SEARCH_NAME, cacheManager = "redisCacheManager",
-            key = "'search:' + #keyword.trim().toLowerCase() + ':' + #pageable.pageNumber + ':' + #pageable.pageSize",
-            condition = "@popularSearchService.isPopular(#keyword)",
-            unless = "#result == null || #result.content.isEmpty()")
     public PageResponse<MovieSearchResponse> searchMoviesWithCache(String keyword, Pageable pageable) {
 
-        log.debug("[SearchService] searchMoviesWithCache Cache miss: keyword: {}, pageSize: {}, pageNumber: {}",
-                keyword, pageable.getPageSize(), pageable.getPageNumber());
+        PopularType popularType = popularSearchService.checkPopularity(keyword);
+
+        log.debug("[SearchService] PopularType: {}, 검색 실행 keyword: {}", popularType, keyword);
+
+        // 종류에 따라 다른 캐시 메서드 호출
+        if (popularType == PopularType.PREVIOUS) {
+            return searchCacheService.searchMoviesForPreviousPopularKeywords(keyword, pageable);
+        } else if (popularType == PopularType.CURRENT) {
+            return searchCacheService.searchMoviesForCurrentPopularKeywords(keyword, pageable);
+        } else {
+            return searchMoviesDirectly(keyword, pageable);
+        }
+    }
+
+    private PageResponse<MovieSearchResponse> searchMoviesDirectly(String keyword, Pageable pageable) {
 
         return PageResponse.from(movieService.searchMovies(keyword, pageable));
     }
-
 }

--- a/src/main/java/org/example/pedia_777/domain/search/service/SearchService.java
+++ b/src/main/java/org/example/pedia_777/domain/search/service/SearchService.java
@@ -29,11 +29,11 @@ public class SearchService {
             key = "'search:' + #keyword.trim().toLowerCase() + ':' + #pageable.pageNumber + ':' + #pageable.pageSize",
             condition = "#keyword != null && #keyword.trim().length() <= 30 && #pageable.pageSize <= 30 && #pageable.pageNumber <= 3",
             unless = "#result == null || #result.content.isEmpty()")
-    public PageResponse<MovieSearchResponse> searchMoviesWithLocalCache(String keyword, Pageable pageable) {
+    public PageResponse<MovieSearchResponse> searchMoviesWithCache(String keyword, Pageable pageable) {
 
-        log.info("[SearchService] searchMoviesWithLocalCache DB 연결 | keyword: {}, pageSize: {}, pageNumber: {}",
-                keyword,
-                pageable.getPageSize(), pageable.getPageNumber());
+        log.debug("[SearchService] searchMoviesWithCache Cache miss: keyword: {}, pageSize: {}, pageNumber: {}",
+                keyword, pageable.getPageSize(), pageable.getPageNumber());
+
         popularSearchService.incrementSearchKeyword(keyword);
         return PageResponse.from(movieService.searchMovies(keyword, pageable));
     }


### PR DESCRIPTION
## 🔗 **연관된 이슈**
> close #9 

<br>

## 📝 **작업 내용**

- [x] In-memory cache (caffeine)을 Redis 캐시로 전환
- [x] release_date 컬럼 b-tree 인덱스 추가
- [x] 검색 API의 기존 캐시 condition을 인기 검색어 여부에 따라 이뤄지도록 수정
- [x] 인기 검색어도 이전 시간대인지, 현재 인기 검색어인지에 따라 캐시 분리

---

- 다른 네이밍 개선은 별도의 issue로 진행할 예정
<br>

## 📸 **스크린샷 (Optional)**

<br>